### PR TITLE
[Fix] Use timestamp as score when ZADD to TS.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,8 +270,8 @@ pub fn insert(ctx: &Context, ts: DateTime<Utc>, data: SparseData) -> Result<()> 
             "ZADD",
             &vec![
                 "TS",
-                id.to_string().as_str(),
                 ts.timestamp().to_string().as_str(),
+                id.to_string().as_str(),
             ],
         )
         .map_err(|err| return anyhow!(err))?;


### PR DESCRIPTION
timestamp should be the "score" of the TS sorted set instead of "member" so it could be get by time range from `get_ids_in_range` function